### PR TITLE
Rename add script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "all-contributors-cli": "^3.0.7"
   },
   "scripts": {
-    "add": "all-contributors add",
+    "add-contributor": "all-contributors add",
     "generate": "all-contributors generate"
   }
 }


### PR DESCRIPTION
Cambio de nombre del script para agregar contributors. Add es "palabra reservada" de yarn, por lo que asi evitamos posibles confusiones.

Nice bonus: Ahora se puede correr con `yarn add-contributor` sin tener que usar `run`