### PR TITLE
fix(examples): fix third option of fourth part of Groupon's exercise

### DIFF
--- a/ejemplos/Groupon/ticktock.md
+++ b/ejemplos/Groupon/ticktock.md
@@ -103,19 +103,16 @@ let tickTock = () => {
 }
 
 /*
-  Opción 3: Intercambiando en una variable `funct`, referencias a las funciones `tick` y `tock` con cada ejecución y llamando a 'funct' en la funcion `tickTock`
+  Opción 3: Aprovechando la coerción de tipos `boolean` a `number`, para transformar valores decimales a caracteres y así poder usar `Function`
 */
-const funct = tick;
-const tick = () => {
-  console.log('tick')
-  funct = tock;
-}
-const tock = () => {
-  console.log('tock');
-  funct = tick;
-}
+let aux = true;
+const tick = () => { console.log('tick'); }
+const tock = () => { console.log('tock'); }
 
 const tickTock = () => {
-  funct();
+  const f = new Function(`t${String.fromCharCode(aux * 6 + 105)}ck()`);
+  f();
+
+  aux = !aux;
 }
 ```


### PR DESCRIPTION
La parte 3 del ejercicio de Groupon nos dice que las funciones tick() y tock() son manejadas por otro equipo, por lo tanto no tendríamos acceso a modificar dichas funciones.

Mi propuesta es aprovechar la coerción de tipos booleanos a enteros (true -> 1, false -> 0), en conjunto a la conversión de valores "Decimales" a caracteres, donde el valor 105 corresponde al carácter "i", mientras que el valor 111 corresponde al carácter "o".

Con esas cosas en cuenta, el código habla por si mismo.